### PR TITLE
Support Python 3.6 and 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Rowan Molony <rowan.molony@codema.ie>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.6 || ^3.7 || ^3.8"
 dask = "^2.30.0"
 prefect = "^0.13.18"
 pyarrow = "^2.0.0"


### PR DESCRIPTION
As Google Collab is rn running on Python 3.6.9