### PR TITLE
Rename variables in elec nbook to avoid clash

### DIFF
--- a/notebooks/cer-electricity-demand-sandbox.ipynb
+++ b/notebooks/cer-electricity-demand-sandbox.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "demands = dd.read_parquet(demand_dirpath)"
+    "demand_ddf = dd.read_parquet(demand_dirpath)"
    ]
   },
   {
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alloactions = pd.read_parquet(allocations_filepath)"
+    "alloactions_df = pd.read_parquet(allocations_filepath)"
    ]
   }
  ],


### PR DESCRIPTION
Google collab confused the module name `allocations` with
the local dataframe `allocations` so change the local df
name