### PR TITLE
Add pre-commit clear jnbook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: jupyter-nb-clear-output
+        name: jupyter-nb-clear-output
+        files: \.ipynb$
+        stages: [commit]
+        language: system
+        entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
+        # source: https://zhauniarovich.com/post/2020/2020-06-clearing-jupyter-output/


### PR DESCRIPTION
So by default clear notebook cells of outputs
prior to commiting to Github